### PR TITLE
Fix integration tests

### DIFF
--- a/order-command-ms/pom.xml
+++ b/order-command-ms/pom.xml
@@ -233,9 +233,16 @@
                                 <include>**/it/**</include>
                             </includes>
                             <systemPropertyVariables>
-                                <liberty.test.port>${http.port}</liberty.test.port>
-                                <war.name>${app.name}</war.name>
-                            </systemPropertyVariables>
+                                <liberty.test.port>${testServerHttpPort}</liberty.test.port>
+                                <war.context>${warContext}</war.context>
+                              </systemPropertyVariables>
+                              <environmentVariables>
+                                <KAFKA_BROKERS>${KAFKA_BROKERS}</KAFKA_BROKERS>
+                                <KAFKA_APIKEY>${KAFKA_APIKEY}</KAFKA_APIKEY>
+                                <TRUSTSTORE_ENABLED>${TRUSTSTORE_ENABLED}</TRUSTSTORE_ENABLED>
+                                <TRUSTSTORE_PATH>${TRUSTSTORE_PATH}</TRUSTSTORE_PATH>
+                                <TRUSTSTORE_PWD>${TRUSTSTORE_PWD}</TRUSTSTORE_PWD>
+                              </environmentVariables>
                         </configuration>
                     </execution>
                     <execution>

--- a/order-command-ms/src/test/java/it/OrderCRUServiceIT.java
+++ b/order-command-ms/src/test/java/it/OrderCRUServiceIT.java
@@ -25,6 +25,7 @@ import ibm.gse.orderms.app.dto.ShippingOrderUpdateParameters;
 import ibm.gse.orderms.domain.model.order.Address;
 import ibm.gse.orderms.domain.model.order.ShippingOrder;
 import ibm.gse.orderms.infrastructure.events.order.OrderEvent;
+import ibm.gse.orderms.infrastructure.events.order.OrderEventPayload;
 import ibm.gse.orderms.infrastructure.kafka.KafkaInfrastructureConfig;
 import ut.ShippingOrderTestDataFactory;
 
@@ -97,7 +98,9 @@ public class OrderCRUServiceIT extends CommonITTest {
     public void shouldUpdateTheQuantity() throws Exception {
     	ShippingOrderCreateParameters orderDTO = ShippingOrderTestDataFactory.orderCreateFixtureWithoutID();
     	Response response = makePostRequest(url, new Gson().toJson(orderDTO));
-    	String orderID = response.readEntity(String.class);
+        String orderJson = response.readEntity(String.class);
+        OrderEventPayload order = new Gson().fromJson(orderJson, OrderEventPayload.class);
+        String orderID = order.getOrderID();
     	System.out.println("shouldUpdateTheQuantity for " + orderID);
     	// Wait the command event to be produced and consumed and data persisted
     	Thread.sleep(5000);


### PR DESCRIPTION
Fix up the integration tests that come with order-command-ms.  These need to run against a Kafka like this: 
```
appsody test --network events_default --docker-options "-e KAFKA_BROKERS=kafka:9092"
```
assuming a local Kafka run with Docker Compose in a network called `events_default`
